### PR TITLE
カラーテーマ設定画面の作成

### DIFF
--- a/app/src/main/java/com/example/gitgrow/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/gitgrow/navigation/NavGraph.kt
@@ -67,7 +67,9 @@ fun NavGraph(
                 )
             },
         ) {
-            ThemeSettingScreen()
+            ThemeSettingScreen(
+                navigateBack = { back() },
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/gitgrow/ui/screen/theme_setting/ThemeSettingScreen.kt
+++ b/app/src/main/java/com/example/gitgrow/ui/screen/theme_setting/ThemeSettingScreen.kt
@@ -5,23 +5,62 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.gitgrow.navigation.Screen
 import com.example.gitgrow.ui.component.GitGrowTopBar
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 @Suppress("ModifierMissing")
 @Composable
-fun ThemeSettingScreen() {
+fun ThemeSettingScreen(
+    navigateBack: () -> Unit,
+    viewModel: ThemeSettingViewModel = viewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    val latestBack by rememberUpdatedState(navigateBack)
+
+    LaunchedEffect(lifecycleOwner, viewModel) {
+        viewModel.uiEvent
+            .flowWithLifecycle(lifecycleOwner.lifecycle)
+            .onEach { event ->
+                when (event) {
+                    is ThemeSettingUiEvent.SelectGitGrowThemeColor -> {
+                        viewModel.selectGitGrowThemeColor()
+                    }
+                    is ThemeSettingUiEvent.SelectDynamicColor -> {
+                        viewModel.selectDynamicColor()
+                    }
+                    is ThemeSettingUiEvent.NavigateBack -> {
+                        latestBack()
+                    }
+                }
+            }
+            .launchIn(this)
+    }
+
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         topBar = {
             GitGrowTopBar(
                 currentScreen = Screen.ThemeSetting,
                 modifier = Modifier.fillMaxWidth(),
+                back = navigateBack,
             )
         },
     ) { innerPadding ->
         ThemeSettingScreenContent(
+            uiState = uiState,
+            onEvent = viewModel::onEvent,
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding),

--- a/app/src/main/java/com/example/gitgrow/ui/screen/theme_setting/ThemeSettingScreenContent.kt
+++ b/app/src/main/java/com/example/gitgrow/ui/screen/theme_setting/ThemeSettingScreenContent.kt
@@ -1,23 +1,88 @@
 package com.example.gitgrow.ui.screen.theme_setting
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import com.example.gitgrow.R
+import com.example.gitgrow.ui.component.BodyMediumText
+import com.example.gitgrow.ui.component.LabelMediumText
+import com.example.gitgrow.ui.theme.UiConfig
 
 @Composable
 fun ThemeSettingScreenContent(
+    uiState: ThemeSettingUiState,
+    onEvent: (ThemeSettingUiEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
+        modifier = modifier
+            .padding(dimensionResource(id = R.dimen.medium_padding)),
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.small_padding)),
     ) {
-        Text(
-            text = "Theme Setting",
+        LabelMediumText(
+            text = "カラーテーマを選択してください",
+        )
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+            shape = MaterialTheme.shapes.medium,
+        ) {
+            Column(
+                modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.medium_padding)),
+            ) {
+                ColorThemeSettingItem(
+                    title = "アプリのカラーテーマを使用する",
+                    selected = uiState.useGitGrowThemeColor,
+                    onClick = { onEvent(ThemeSettingUiEvent.SelectGitGrowThemeColor) },
+
+                )
+                HorizontalDivider(
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                ColorThemeSettingItem(
+                    title = "ダイナミックカラーを使用する",
+                    selected = uiState.useDynamicColor,
+                    onClick = { onEvent(ThemeSettingUiEvent.SelectDynamicColor) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ColorThemeSettingItem(
+    title: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .height(dimensionResource(id = R.dimen.item_height))
+            .clickable(
+                onClick = onClick,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        BodyMediumText(
+            text = title,
+            modifier = Modifier.weight(UiConfig.DefaultWeight),
+        )
+        RadioButton(
+            selected = selected,
+            onClick = onClick,
         )
     }
 }

--- a/app/src/main/java/com/example/gitgrow/ui/screen/theme_setting/ThemeSettingUiEvent.kt
+++ b/app/src/main/java/com/example/gitgrow/ui/screen/theme_setting/ThemeSettingUiEvent.kt
@@ -1,0 +1,7 @@
+package com.example.gitgrow.ui.screen.theme_setting
+
+sealed interface ThemeSettingUiEvent {
+    data object SelectGitGrowThemeColor : ThemeSettingUiEvent
+    data object SelectDynamicColor : ThemeSettingUiEvent
+    data object NavigateBack : ThemeSettingUiEvent
+}

--- a/app/src/main/java/com/example/gitgrow/ui/screen/theme_setting/ThemeSettingUiState.kt
+++ b/app/src/main/java/com/example/gitgrow/ui/screen/theme_setting/ThemeSettingUiState.kt
@@ -1,0 +1,6 @@
+package com.example.gitgrow.ui.screen.theme_setting
+
+data class ThemeSettingUiState(
+    val useGitGrowThemeColor: Boolean = true,
+    val useDynamicColor: Boolean = false,
+)

--- a/app/src/main/java/com/example/gitgrow/ui/screen/theme_setting/ThemeSettingViewModel.kt
+++ b/app/src/main/java/com/example/gitgrow/ui/screen/theme_setting/ThemeSettingViewModel.kt
@@ -1,0 +1,42 @@
+package com.example.gitgrow.ui.screen.theme_setting
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class ThemeSettingViewModel : ViewModel() {
+    private val _uiState = MutableStateFlow(ThemeSettingUiState())
+    val uiState: StateFlow<ThemeSettingUiState> = _uiState.asStateFlow()
+
+    private val _uiEvent = MutableSharedFlow<ThemeSettingUiEvent>()
+    val uiEvent: MutableSharedFlow<ThemeSettingUiEvent> = _uiEvent
+
+    fun selectGitGrowThemeColor() {
+        _uiState.update {
+            it.copy(
+                useGitGrowThemeColor = true,
+                useDynamicColor = false,
+            )
+        }
+    }
+
+    fun selectDynamicColor() {
+        _uiState.update {
+            it.copy(
+                useGitGrowThemeColor = false,
+                useDynamicColor = true,
+            )
+        }
+    }
+
+    fun onEvent(event: ThemeSettingUiEvent) {
+        viewModelScope.launch {
+            _uiEvent.emit(event)
+        }
+    }
+}

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -3,6 +3,8 @@
 
     <dimen name="top_app_bar_height">64.dp</dimen>
 
+    <dimen name="item_height">56.dp</dimen>
+
     <dimen name="medium_padding">15.dp</dimen>
     <dimen name="small_padding">5.dp</dimen>
 </resources>


### PR DESCRIPTION
## 概要
カラーテーマ設定画面を作成
カラーテーマ設定画面とは、大まかに説明するとアプリ固有のカラーテーマを使用するか、ダイナミックカラーのカラーテーマを使用するかどうかを選択する画面
詳しい要件については、Issue#9を参照
どちらを使用するか、ラジオボタンで実装

## 実施Issue
#9 

<!-- UIに変更があった際に使用 -->
## UI変更
| After |
|-------|
| <img src="https://github.com/user-attachments/assets/b0ea285e-8a69-4d58-b77b-b8618fc461ee" width="300" /> |

