### PR TITLE
各画面の項目の高さ統一

### DIFF
--- a/app/src/main/java/com/example/gitgrow/ui/component/GitGrowTextField.kt
+++ b/app/src/main/java/com/example/gitgrow/ui/component/GitGrowTextField.kt
@@ -2,11 +2,13 @@ package com.example.gitgrow.ui.component
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.dimensionResource
@@ -27,7 +29,9 @@ fun GitGrowTextField(
     ) {
         Box(
             modifier = Modifier
-                .padding(dimensionResource(id = R.dimen.medium_padding)),
+                .height(dimensionResource(id = R.dimen.item_height))
+                .padding(horizontal = dimensionResource(id = R.dimen.medium_padding)),
+            contentAlignment = Alignment.CenterStart,
         ) {
             if (text.isEmpty()) {
                 BodyMediumText(

--- a/app/src/main/java/com/example/gitgrow/ui/screen/settings/SettingsScreenContent.kt
+++ b/app/src/main/java/com/example/gitgrow/ui/screen/settings/SettingsScreenContent.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowRight
@@ -117,7 +118,8 @@ fun SettingItem(
 ) {
     Row(
         modifier = modifier
-            .padding(dimensionResource(id = R.dimen.medium_padding)),
+            .height(dimensionResource(id = R.dimen.item_height))
+            .padding(horizontal = dimensionResource(id = R.dimen.medium_padding)),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(

--- a/app/src/main/java/com/example/gitgrow/ui/screen/theme_setting/ThemeSettingScreenContent.kt
+++ b/app/src/main/java/com/example/gitgrow/ui/screen/theme_setting/ThemeSettingScreenContent.kt
@@ -39,22 +39,23 @@ fun ThemeSettingScreenContent(
             color = MaterialTheme.colorScheme.surfaceContainerHighest,
             shape = MaterialTheme.shapes.medium,
         ) {
-            Column(
-                modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.medium_padding)),
-            ) {
+            Column {
                 ColorThemeSettingItem(
                     title = "アプリのカラーテーマを使用する",
                     selected = uiState.useGitGrowThemeColor,
                     onClick = { onEvent(ThemeSettingUiEvent.SelectGitGrowThemeColor) },
-
+                    modifier = Modifier.fillMaxWidth(),
                 )
                 HorizontalDivider(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = dimensionResource(id = R.dimen.medium_padding)),
                 )
                 ColorThemeSettingItem(
                     title = "ダイナミックカラーを使用する",
                     selected = uiState.useDynamicColor,
                     onClick = { onEvent(ThemeSettingUiEvent.SelectDynamicColor) },
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
         }
@@ -70,10 +71,11 @@ private fun ColorThemeSettingItem(
 ) {
     Row(
         modifier = modifier
-            .height(dimensionResource(id = R.dimen.item_height))
             .clickable(
                 onClick = onClick,
-            ),
+            )
+            .height(dimensionResource(id = R.dimen.item_height))
+            .padding(horizontal = dimensionResource(id = R.dimen.medium_padding)),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         BodyMediumText(


### PR DESCRIPTION
## 概要
設定画面（トップ）やカラーテーマ設定画面には幾つか項目がある。それぞれの項目の高さの指定方法を統一させた。
特定の値を用意し、heightをその値に合わせるという方法で統一した。
変更に伴い、RippleEffectがPaddingの影響もあり予期せぬようになってしまったため、それに関わる変更も行った。

## 実施Issue
#12

<!-- UIに変更があった際に使用 -->
## UI変更
UIに関するPull Requestだが、大きな変更があるわけではないためなし